### PR TITLE
Send Signal when updating aggregators

### DIFF
--- a/completion_aggregator/batch.py
+++ b/completion_aggregator/batch.py
@@ -15,7 +15,7 @@ import time
 import six
 
 from . import models, utils
-from .tasks import aggregation_tasks
+from . import tasks
 
 log = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ def perform_aggregation(batch_size=10000, delay=0.0, limit=None, routing_key=Non
             blocks = []
         else:
             blocks = [six.text_type(block_key) for block_key in stale_blocks[enrollment]]
-        aggregation_tasks.update_aggregators.apply_async(
+        tasks.aggregation_tasks.update_aggregators.apply_async(
             kwargs={
                 'username': enrollment.username,
                 'course_key': six.text_type(enrollment.course_key),

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -24,6 +24,7 @@ from . import tracking
 from .cachegroup import CacheGroup
 from .models import Aggregator, StaleCompletion
 
+from . import signals
 from .utils import BagOfHolding
 
 
@@ -218,8 +219,7 @@ class AggregationUpdater(object):
         Aggregator.objects.bulk_create_or_update(updated_aggregators)
         self.resolve_stale_completions(changed_blocks, start)
 
-        from .signals import AGGREGATORS_UPDATED  # avoid circular imports
-        AGGREGATORS_UPDATED.send(sender=self.__class__, aggregators=updated_aggregators)
+        signals.AGGREGATORS_UPDATED.send(sender=self.__class__, aggregators=updated_aggregators)
 
     def update_for_block(self, block, affected_aggregators, force=False):
         """

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -23,6 +23,7 @@ from . import compat
 from . import tracking
 from .cachegroup import CacheGroup
 from .models import Aggregator, StaleCompletion
+
 from .utils import BagOfHolding
 
 
@@ -216,6 +217,9 @@ class AggregationUpdater(object):
         updated_aggregators = self.calculate_updated_aggregators(changed_blocks, force)
         Aggregator.objects.bulk_create_or_update(updated_aggregators)
         self.resolve_stale_completions(changed_blocks, start)
+
+        from .signals import AGGREGATORS_UPDATED  # avoid circular imports
+        AGGREGATORS_UPDATED.send(sender=self.__class__, aggregators=updated_aggregators)
 
     def update_for_block(self, block, affected_aggregators, force=False):
         """

--- a/completion_aggregator/signals.py
+++ b/completion_aggregator/signals.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
+from django.dispatch import Signal
 from django.conf import settings
 from django.db.models.signals import post_save
 
@@ -12,6 +13,9 @@ from . import batch, compat, models
 from .tasks import handler_tasks
 
 log = logging.getLogger(__name__)
+
+
+AGGREGATORS_UPDATED = Signal(providing_args=["aggregators"])
 
 
 def register():

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -8,7 +8,7 @@ import collections
 
 from mock import MagicMock
 
-from django.conf import settings 
+from django.conf import settings
 
 from completion.models import BlockCompletion
 

--- a/test_utils/test_mixins.py
+++ b/test_utils/test_mixins.py
@@ -96,4 +96,3 @@ class CompletionAPITestMixin(object):
             possible=possible,
             last_modified=timezone.now()
         )
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -241,6 +241,22 @@ class AggregationUpdaterTestCase(TestCase):
                 mock_track_func.assert_any_call(agg, False, True)
 
 
+    @XBlock.register_temp_plugin(CourseBlock, 'course')
+    @XBlock.register_temp_plugin(OtherAggBlock, 'chapter')
+    @mock.patch('completion_aggregator.signals.AGGREGATORS_UPDATED.send')
+    def test_signal_sent_on_update(self, mock_send_signal):
+        """
+        Test that the AGGREGATOR_UPDATED signal is sent w/correct args when aggregators are updated.
+        """
+        self.agg.delete()
+        self.updater = AggregationUpdater(self.user, self.course_key, mock.MagicMock())
+        self.updater.update()
+        mock_send_signal.assert_any_call(
+            sender=self.updater.__class__, 
+            aggregators=self.updater.updated_aggregators
+        )
+
+
 class CalculateUpdatedAggregatorsTestCase(TestCase):
     """
     Test that AggragationUpdater.calculate_updated_aggregators() finds the latest completions.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -252,7 +252,7 @@ class AggregationUpdaterTestCase(TestCase):
         self.updater = AggregationUpdater(self.user, self.course_key, mock.MagicMock())
         self.updater.update()
         mock_send_signal.assert_any_call(
-            sender=self.updater.__class__, 
+            sender=self.updater.__class__,
             aggregators=self.updater.updated_aggregators
         )
 


### PR DESCRIPTION
AggregationUpdater Send a Django Signal after updating aggregators.  Provides a hook for taking other action when aggregators are changed.
