### PR TITLE
Pass course org and user id to tracking events.

### DIFF
--- a/completion_aggregator/tracking.py
+++ b/completion_aggregator/tracking.py
@@ -37,6 +37,8 @@ def track_aggregator_event(aggregator, event_type):
     agg_type = aggregator.aggregation_name
     block_id = str(aggregator.block_key)
     course_id = str(aggregator.course_key)
+    org = aggregator.course_key.org
+    user_id = aggregator.user.id
     percent = aggregator.percent * 100
     earned = aggregator.earned
     possible = aggregator.possible
@@ -69,6 +71,10 @@ def track_aggregator_event(aggregator, event_type):
             'completion_percent': percent,
             'course_name': course_name,
             'block_name': block_name,
+            'org': org,  # helpful to find Segment Key by Site
+            'context': {  # event may not be created from a request context but will need user id
+                'user_id': user_id
+            }
         })
 
     # generic tracking event
@@ -82,6 +88,10 @@ def track_aggregator_event(aggregator, event_type):
         'completion_earned': earned,
         'completion_possible': possible,
         'block_type': agg_type,
+        'org': org,
+        'context': {
+            'user_id': user_id
+        }
     })
 
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -30,6 +30,8 @@ EXPECTED_EVENT_DATA_GENERIC_STARTED = {
     'completion_percent': 10.0,
     'completion_earned': 0.1,
     'completion_possible': 1.0,
+    'org': 'Appsembler',
+    'context': {'user_id': 1}
 }
 
 EXPECTED_EVENT_DATA_GENERIC_COMPLETED = copy(EXPECTED_EVENT_DATA_GENERIC_STARTED)
@@ -96,6 +98,16 @@ class EventTrackingTestCase(CompletionAPITestMixin, TestCase):
             possible=1.0,
             last_modified=now(),
         )
+        # update with correct user id
+        for event in (
+            EXPECTED_EVENT_DATA_GENERIC_STARTED,
+            EXPECTED_EVENT_DATA_GENERIC_COMPLETED,
+            EXPECTED_EVENT_DATA_GENERIC_REVOKED,
+            EXPECTED_EVENT_DATA_BI_STARTED,
+            EXPECTED_EVENT_DATA_BI_COMPLETED,
+            EXPECTED_EVENT_DATA_BI_REVOKED
+        ):
+            event['context']['user_id'] = self.test_user.id
 
         for compat_import in (
                 'completion_aggregator.tracking.compat',


### PR DESCRIPTION
The thread handling tracking events will usually not have the original request object.  Include org as hook for doing Site-specific things in Processors or Backends.
Include user_id as necessary event information.
