### PR TITLE
Include user email in BI event

### DIFF
--- a/completion_aggregator/tracking.py
+++ b/completion_aggregator/tracking.py
@@ -39,6 +39,7 @@ def track_aggregator_event(aggregator, event_type):
     course_id = str(aggregator.course_key)
     org = aggregator.course_key.org
     user_id = aggregator.user.id
+    email = aggregator.user.email
     percent = aggregator.percent * 100
     earned = aggregator.earned
     possible = aggregator.possible
@@ -71,6 +72,7 @@ def track_aggregator_event(aggregator, event_type):
             'completion_percent': percent,
             'course_name': course_name,
             'block_name': block_name,
+            'email': email,  # TODO: temp - needed to award badges via Segment. revert when not needed
             'org': org,  # helpful to find Segment Key by Site
             'context': {  # event may not be created from a request context but will need user id
                 'user_id': user_id

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -53,6 +53,7 @@ EXPECTED_EVENT_DATA_BI_STARTED.update({
     'label': 'course Appsembler Aggregation Events 101 started',
     'course_name': 'Appsembler Aggregation Events 101',
     'block_name': 'Appsembler Aggregation Events 101',
+    'email': ''
 })
 
 EXPECTED_EVENT_DATA_BI_COMPLETED = copy(EXPECTED_EVENT_DATA_GENERIC_COMPLETED)
@@ -60,6 +61,7 @@ EXPECTED_EVENT_DATA_BI_COMPLETED.update({
     'label': 'course Appsembler Aggregation Events 101 completed',
     'course_name': 'Appsembler Aggregation Events 101',
     'block_name': 'Appsembler Aggregation Events 101',
+    'email': ''
 })
 
 EXPECTED_EVENT_DATA_BI_REVOKED = copy(EXPECTED_EVENT_DATA_GENERIC_REVOKED)
@@ -67,6 +69,7 @@ EXPECTED_EVENT_DATA_BI_REVOKED.update({
     'label': 'course Appsembler Aggregation Events 101 completion revoked',
     'course_name': 'Appsembler Aggregation Events 101',
     'block_name': 'Appsembler Aggregation Events 101',
+    'email': ''
 })
 
 # bi events don't need as much detail


### PR DESCRIPTION
To award badges via Segment event, we need the email address in the event. 