### PR TITLE
Fix tracking event label bug: use unicode literals in tracking module

### DIFF
--- a/completion_aggregator/tracking.py
+++ b/completion_aggregator/tracking.py
@@ -3,13 +3,15 @@
 Tracking and analytics events for completion aggregator activities.
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from eventtracking import tracker
 
 from . import compat
 
 
-TRACKER_BI_EVENT_NAME_FORMAT = u'edx.bi.completion.user.{agg_type}.{event_type}'
-TRACKER_EVENT_NAME_FORMAT = u'edx.completion.aggregator.{event_type}'
+TRACKER_BI_EVENT_NAME_FORMAT = 'edx.bi.completion.user.{agg_type}.{event_type}'
+TRACKER_EVENT_NAME_FORMAT = 'edx.completion.aggregator.{event_type}'
 TRACKER_VALID_EVENT_TYPES = {'completed', 'started', 'revoked', }
 
 

--- a/test_utils/test_app/models.py
+++ b/test_utils/test_app/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Models to be used in tests
 """
@@ -116,7 +117,7 @@ class CourseStructure(models.Model):
             'blocks': {
                 'block-v1:Appsembler+AggEvents101+2020+type@course+block@course': {
                     'block_type': 'course',
-                    'display_name': 'Appsembler Aggregation Events 101',
+                    'display_name': 'Appsembler Aggrégatiòn Events 101',
                 }
             }
         }

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
 """
 Test event tracking functions.
 """
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from copy import copy
@@ -50,25 +52,25 @@ EXPECTED_EVENT_DATA_GENERIC_REVOKED.update({
 
 EXPECTED_EVENT_DATA_BI_STARTED = copy(EXPECTED_EVENT_DATA_GENERIC_STARTED)
 EXPECTED_EVENT_DATA_BI_STARTED.update({
-    'label': 'course Appsembler Aggregation Events 101 started',
-    'course_name': 'Appsembler Aggregation Events 101',
-    'block_name': 'Appsembler Aggregation Events 101',
+    'label': 'course Appsembler Aggrégatiòn Events 101 started',
+    'course_name': 'Appsembler Aggrégatiòn Events 101',
+    'block_name': 'Appsembler Aggrégatiòn Events 101',
     'email': ''
 })
 
 EXPECTED_EVENT_DATA_BI_COMPLETED = copy(EXPECTED_EVENT_DATA_GENERIC_COMPLETED)
 EXPECTED_EVENT_DATA_BI_COMPLETED.update({
-    'label': 'course Appsembler Aggregation Events 101 completed',
-    'course_name': 'Appsembler Aggregation Events 101',
-    'block_name': 'Appsembler Aggregation Events 101',
+    'label': 'course Appsembler Aggrégatiòn Events 101 completed',
+    'course_name': 'Appsembler Aggrégatiòn Events 101',
+    'block_name': 'Appsembler Aggrégatiòn Events 101',
     'email': ''
 })
 
 EXPECTED_EVENT_DATA_BI_REVOKED = copy(EXPECTED_EVENT_DATA_GENERIC_REVOKED)
 EXPECTED_EVENT_DATA_BI_REVOKED.update({
-    'label': 'course Appsembler Aggregation Events 101 completion revoked',
-    'course_name': 'Appsembler Aggregation Events 101',
-    'block_name': 'Appsembler Aggregation Events 101',
+    'label': 'course Appsembler Aggrégatiòn Events 101 completion revoked',
+    'course_name': 'Appsembler Aggrégatiòn Events 101',
+    'block_name': 'Appsembler Aggrégatiòn Events 101',
     'email': ''
 })
 


### PR DESCRIPTION
Add  `unicode_literals` import missing in tracking and test_app.models.  Fixes https://appsembler.atlassian.net/browse/BLACK-945
