### PR TITLE
tracking - track as new any aggregator moving from 0 to above 0 percent whether or not it has been saved before

### DIFF
--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -282,12 +282,12 @@ class AggregationUpdater(object):
             else:
                 aggregator = self.aggregators[block]
                 completion_revoked = True if aggregator.percent == 1.0 and percent < 1.0 else False
+                is_new = True if aggregator.percent == 0.0 and percent > 0.0 else False
                 aggregator.earned = total_earned
                 aggregator.possible = total_possible
                 aggregator.percent = percent
                 aggregator.last_modified = last_modified
                 aggregator.modified = timezone.now()
-                is_new = False
             self.updated_aggregators.append(aggregator)
 
             # evaluate for tracking events

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -228,7 +228,7 @@ class AggregationUpdaterTestCase(TestCase):
         self.updater = AggregationUpdater(self.user, self.course_key, mock.MagicMock())
         self.updater.update()
         for agg in self.updater.aggregators.values():
-            mock_track_func.assert_any_call(agg, False, False)
+            mock_track_func.assert_any_call(agg, True, False)
 
         # test for revoked completion call
         mock_track_func.reset_mock()


### PR DESCRIPTION
Fixes situation where an Aggregator is created at 0.0 percent but we still need to track the 'started' events later when the percent moves above zero.