### PR TITLE
Fix the mark_all_stale handler that marks completions as stale and needing update

### DIFF
--- a/completion_aggregator/cachegroup.py
+++ b/completion_aggregator/cachegroup.py
@@ -75,7 +75,7 @@ class CacheGroup(object):
         """
         Invalidate an entire entry from the cache.
         """
-        CacheGroupInvalidation.objects.create_or_update(group=group, invalidated_at=timezone.now())
+        CacheGroupInvalidation.objects.update_or_create(group=group, invalidated_at=timezone.now())
 
         # Group invalidations are expected to be relatively infrequent, so we
         # take this opportunity to clean old invalidation records out of the


### PR DESCRIPTION
Arg, an upstream bug I hadn't found. 

Thisi handles course publishes, cohort changes and other Studio events that can change what's been completed by a user. Fix the method name for cache group deletion.